### PR TITLE
Get method sends headers if provided

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,14 +1,15 @@
 {
-    "perl"        : "6.*",
-    "name"        : "LWP::Simple",
-    "version"     : "0.090",
-    "description" : "LWP::Simple quick & dirty implementation for Rakudo Perl 6",
-    "depends"     : [ "MIME::Base64", "URI" ],
-    "provides"    : {
+    "perl"         : "6.*",
+    "name"         : "LWP::Simple",
+    "version"      : "0.090",
+    "description"  : "LWP::Simple quick & dirty implementation for Rakudo Perl 6",
+    "depends"      : [ "MIME::Base64", "URI" ],
+    "test-depends" : [ "JSON::Tiny" ],
+    "provides"     : {
         "LWP::Simple" : "lib/LWP/Simple.pm"
     },
-    "author"      : "Cosimo Streppone",
-    "authority"   : "perl6",
-    "source-url"  : "git://github.com/perl6/perl6-lwp-simple.git"
+    "author"       : "Cosimo Streppone",
+    "authority"    : "perl6",
+    "source-url"   : "git://github.com/perl6/perl6-lwp-simple.git"
 }
 

--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -29,7 +29,7 @@ method base64encode ($user, $pass) {
 }
 
 method get (Str $url, %headers = {}) {
-    self.request_shell(RequestType::GET, $url)
+    self.request_shell(RequestType::GET, $url, %headers)
 }
 
 method delete (Str $url, %headers = {}) {

--- a/t/get-headers.t
+++ b/t/get-headers.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+use LWP::Simple;
+use JSON::Tiny;
+
+plan 2;
+
+if %*ENV<NO_NETWORK_TESTING> {
+    diag "NO_NETWORK_TESTING was set";
+    skip-rest("NO_NETWORK_TESTING was set");
+    exit;
+}
+
+my %headers =
+    "Accept"     => "application/json",
+    "User-Agent" => "Perl 6",
+;
+
+my $html = LWP::Simple.get('http://httpbin.org/get', %headers);
+my %json = from-json $html;
+
+is %json<headers><User-Agent>, "Perl 6", "User agent header is sent by GET";
+is %json<headers><Accept>, "application/json", "Accept header is sent by GET";


### PR DESCRIPTION
Fixes #14 

Very simple fix. However, I am slightly uncomfortable with introducing JSON::Tiny as a test dependency (to quieten the deprecated code warning for from-json) - have made changes to the META6.json file also to add this to test dependencies. If the dependency is undesired, let me know and I'll fix it somehow.