### PR TITLE
HTML header names with mixed case fix

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl"         : "6.*",
     "name"         : "LWP::Simple",
-    "version"      : "0.095",
+    "version"      : "0.096",
     "description"  : "LWP::Simple quick & dirty implementation for Rakudo Perl 6",
     "depends"      : [ "MIME::Base64", "URI" ],
     "test-depends" : [ "JSON::Tiny" ],
@@ -12,4 +12,3 @@
     "authority"    : "perl6",
     "source-url"   : "git://github.com/perl6/perl6-lwp-simple.git"
 }
-

--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -6,9 +6,9 @@ use MIME::Base64;
 use URI;
 use URI::Escape;
 
-unit class LWP::Simple:auth<cosimo>:ver<0.096>;
+unit class LWP::Simple:auth<cosimo>:ver<0.094>;
 
-our $VERSION = '0.096';
+our $VERSION = '0.094';
 
 enum RequestType <GET POST PUT HEAD DELETE>;
 
@@ -332,8 +332,7 @@ method parse_response (Blob $resp) {
 
         for @header_lines {
             my ($name, $value) = .split(': ');
-            # HTML header names are case insensitive. Change them to Title-Case.
-            %header{$name.tc} = $value;
+            %header{$name} = $value;
         }
         return $status_line, %header.item, $resp.subbuf($header_end_pos +4).item;
     }

--- a/lib/LWP/Simple.pm
+++ b/lib/LWP/Simple.pm
@@ -6,9 +6,9 @@ use MIME::Base64;
 use URI;
 use URI::Escape;
 
-unit class LWP::Simple:auth<cosimo>:ver<0.094>;
+unit class LWP::Simple:auth<cosimo>:ver<0.096>;
 
-our $VERSION = '0.094';
+our $VERSION = '0.096';
 
 enum RequestType <GET POST PUT HEAD DELETE>;
 
@@ -324,7 +324,8 @@ method parse_response (Blob $resp) {
 
         for @header_lines {
             my ($name, $value) = .split(': ');
-            %header{$name} = $value;
+            # HTML header names are case insensitive. Change them to Title-Case.
+            %header{$name.tc} = $value;
         }
         return $status_line, %header.item, $resp.subbuf($header_end_pos +4).item;
     }


### PR DESCRIPTION
So, second try ^^
This time I do not change the header hash itself for compatibility. Instead I create a second hash where it is used to read out information like location or content-type or charset respectively.

This way, old code will work except the code expect to get the buffer back instead of the content because of the bug.

I use a lowercase hash instead of the Title-Case suggestion by zoffix, because that would also change the hash keys and would cause compatibility troubles.